### PR TITLE
Remove lf-permalinkPath due to possible xss attack.

### DIFF
--- a/src/check-permalink.js
+++ b/src/check-permalink.js
@@ -19,12 +19,9 @@ var packageName = 'streamhub-permalink';
  */
 exports.load = function (content, opt_href) {
     var href = opt_href || window.location.href;
-    var packagePath = getParam(href, 'lf-permalinkPath');
     var version = getParam(href, 'lf-permalinkVersion') || defaultVersion;
 
-    lfRequire.require([
-        packagePath ? packagePath : (packageName + '#' + version)
-    ], function (PermalinkPackage) {
+    lfRequire.require([packageName + '#' + version], function (PermalinkPackage) {
         console.log('loaded permalink package', PermalinkPackage);
     });
 };

--- a/test/spec/check-permalink.js
+++ b/test/spec/check-permalink.js
@@ -7,16 +7,8 @@ describe('src/check-permalink', function () {
     it('gets the dynamic version from a query param', function () {
         var spy = sinon.spy(Livefyre, 'require');
         permalink.load(null, 'http://abc.com/?lf-permalinkVersion=0.1.2');
-        expect(spy.callCount).to.equal(1); 
+        expect(spy.callCount).to.equal(1);
         expect(spy.lastCall.args[0][0]).to.equal('//cdn.livefyre.com/libs/streamhub-permalink/v0.1.2/streamhub-permalink.min.js');
-        spy.restore();
-    });
-
-    it('gets the dynamic package path from a query param', function () {
-        var spy = sinon.spy(Livefyre, 'require');
-        permalink.load(null, 'http://abc.com/?lf-permalinkPath=https%3A%2F%2Flivefyre-cdn-dev.s3.amazonaws.com%2Fblah%2Fv6.6.6%2Fstreamhub-permalink.min.js');
-        expect(spy.callCount).to.equal(1); 
-        expect(spy.lastCall.args[0][0]).to.equal('https://livefyre-cdn-dev.s3.amazonaws.com/blah/v6.6.6/streamhub-permalink.min.js');
         spy.restore();
     });
 


### PR DESCRIPTION
In particular, this was vulnerable to url encoding full urls that
execute on load.

